### PR TITLE
Add support for server passwords

### DIFF
--- a/autobot.conf.template
+++ b/autobot.conf.template
@@ -4,6 +4,7 @@ port = 7000
 channels = ##test, ##test2
 nick = autobot
 nickpass = password
+serverpass = serverpassword
 name = Bot
 ssl = True
 

--- a/src/autobot.py
+++ b/src/autobot.py
@@ -32,6 +32,7 @@ class AutoBot(irc.bot.SingleServerIRCBot):
         self.name = self.config.get("irc", "name")
         self.network = self.config.get("irc", "network")
         self.port = int(self.config.get("irc", "port"))
+        self.serverpass = self.config.get("irc", "serverpass")
         self._ssl = self.config.getboolean("irc", "ssl")
         self.channel_list = [channel.strip() for channel in self.config.get("irc", "channels").split(",")]
         self.prefix = self.config.get("bot", "prefix")
@@ -44,7 +45,7 @@ class AutoBot(irc.bot.SingleServerIRCBot):
         else:
             factory = irc.connectionFactory()
         try:
-            irc.bot.SingleServerIRCBot.__init__(self, [(self.network, self.port)],
+            irc.bot.SingleServerIRCBot.__init__(self, [(self.network, self.port, self.serverpass)],
                                                 self.nick, self.name,
                                                 reconnection_interval=120,
                                                 connect_factory = factory)


### PR DESCRIPTION
The underlying irc.bot.SingleServerIRCBot that we use
has support for server passwords.

https://github.com/jaraco/irc/blob/011057a76a890b36a563dc79c1e24073adf1e95c/irc/bot.py#L181

Added a serverpass config parameter to the conf template.
And pass that value in when initializing the SingleServerIRCBot.